### PR TITLE
Codacy & beginning of 'activity' index 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This application utilizes a PostgreSQL database. The Docker Hub image usgswma/wq
 ### Environment variables
 Create an application.yml file in the project directory containing the following (shown are example values - they should match the values you used in creating the etlDB):
 
-```
+```yml
 WQP_DATABASE_ADDRESS: <localhost>
 WQP_DATABASE_PORT: <5437>
 WQP_DATABASE_NAME: <wqp_db>
@@ -40,38 +40,41 @@ CONTEXTS: external,ci,schemaLoad
 ```
 
 #### Environment variable definitions
-* **WQP_DATABASE_ADDRESS** - Host name or IP address of the PostgreSQL database.
-* **WQP_DATABASE_PORT** - Port the PostgreSQL Database is listening on.
-* **WQP_DATABASE_NAME** - Name of the PostgreSQL database containing the schema.
-* **WQP_SCHEMA_NAME** - Name of the schema holding database objects.
-* **WQP_SCHEMA_OWNER_USERNAME** - Role which owns the database objects.
-* **WQP_SCHEMA_OWNER_PASSWORD** - Password for the **WQP_SCHEMA_OWNER_USERNAME** role.
+##### WQP Schema
+*   **WQP_DATABASE_ADDRESS** - Host name or IP address of the PostgreSQL database.
+*   **WQP_DATABASE_PORT** - Port the PostgreSQL Database is listening on.
+*   **WQP_DATABASE_NAME** - Name of the PostgreSQL database containing the schema.
+*   **WQP_SCHEMA_NAME** - Name of the schema holding database objects.
+*   **WQP_SCHEMA_OWNER_USERNAME** - Role which owns the database objects.
+*   **WQP_SCHEMA_OWNER_PASSWORD** - Password for the **WQP_SCHEMA_OWNER_USERNAME** role.
 
-* **NWIS_DATABASE_ADDRESS** - Host name or IP address of the PostgreSQL database.
-* **NWIS_DATABASE_PORT** - Port the PostgreSQL Database is listening on.
-* **NWIS_DATABASE_NAME** - Name of the PostgreSQL database containing the schema.
-* **NWIS_SCHEMA_OWNER_USERNAME** - Role which owns the **NWIS_SCHEMA_NAME** database objects.
-* **NWIS_SCHEMA_OWNER_PASSWORD** - Password for the **NWIS_SCHEMA_OWNER_USERNAME** role.
+##### NWIS Schema
+*   **NWIS_DATABASE_ADDRESS** - Host name or IP address of the PostgreSQL database.
+*   **NWIS_DATABASE_PORT** - Port the PostgreSQL Database is listening on.
+*   **NWIS_DATABASE_NAME** - Name of the PostgreSQL database containing the schema.
+*   **NWIS_SCHEMA_OWNER_USERNAME** - Role which owns the **NWIS_SCHEMA_NAME** database objects.
+*   **NWIS_SCHEMA_OWNER_PASSWORD** - Password for the **NWIS_SCHEMA_OWNER_USERNAME** role.
 
-* **ETL_OWNER_USERNAME** - Role which owns the source schema database objects.
-* **GEO_SCHEMA_NAME** - Name of the schema holding geospatial lookup database objects.
-* **ETL_DATA_SOURCE_ID** - Database ID of the data_source (data_source_id from the **WQP_SCHEMA_NAME**.data_source table).
-* **ETL_DATA_SOURCE** - Data Source name (text from the **WQP_SCHEMA_NAME**.data_source table).
-* **QWPORTAL_SUMMARY_ETL** - Does the ETL populate the qwportal_summary table? true or false.
-* **NWIS_OR_EPA** - If **QWPORTAL_SUMMARY_ETL** is true, is this an NIWS (N) or STORET WQX (E) ETL.
-* **CONTEXTS** - Only used when running the Docker database. Should always be external,ci,schemaLoad.
+##### Miscellaneous
+*   **ETL_OWNER_USERNAME** - Role which owns the source schema database objects.
+*   **GEO_SCHEMA_NAME** - Name of the schema holding geospatial lookup database objects.
+*   **ETL_DATA_SOURCE_ID** - Database ID of the data_source (data_source_id from the **WQP_SCHEMA_NAME**.data_source table).
+*   **ETL_DATA_SOURCE** - Data Source name (text from the **WQP_SCHEMA_NAME**.data_source table).
+*   **QWPORTAL_SUMMARY_ETL** - Does the ETL populate the qwportal_summary table? true or false.
+*   **NWIS_OR_EPA** - If **QWPORTAL_SUMMARY_ETL** is true, is this an NIWS (N) or STORET WQX (E) ETL.
+*   **CONTEXTS** - Only used when running the Docker database. Should always be external,ci,schemaLoad.
 
 ### Testing
 This project contains JUnit tests. Maven can be used to run them (in addition to the capabilities of your IDE).
 
 To run the unit tests of the application use:
 
-```
+```shell
 mvn package
 ```
 
 To additionally start up a Docker database and run the integration tests of the application use:
 
-```
+```shell
 mvn verify
 ```

--- a/src/main/java/gov/acwi/wqp/etl/activity/index/BuildActivityActivityIndex.java
+++ b/src/main/java/gov/acwi/wqp/etl/activity/index/BuildActivityActivityIndex.java
@@ -1,0 +1,28 @@
+package gov.acwi.wqp.etl.activity.index;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import gov.acwi.wqp.etl.EtlConstantUtils;
+import gov.acwi.wqp.etl.activity.Activity;
+import gov.acwi.wqp.etl.index.BuildActivityIndex;
+
+@Component
+@StepScope
+public class BuildActivityActivityIndex extends BuildActivityIndex {
+
+	@Autowired
+	public BuildActivityActivityIndex(JdbcTemplate jdbcTemplate,
+			@Value(EtlConstantUtils.VALUE_JOB_PARM_DATA_SOURCE) String wqpDataSource,
+			@Value(EtlConstantUtils.VALUE_JOB_PARM_WQP_SCHEMA) String wqpSchemaName) {
+		super(jdbcTemplate, wqpDataSource, wqpSchemaName);
+	}
+
+	protected String getBaseTableName() {
+		return Activity.BASE_TABLE_NAME;
+	}
+
+}

--- a/src/main/java/gov/acwi/wqp/etl/activity/index/BuildActivityIndexes.java
+++ b/src/main/java/gov/acwi/wqp/etl/activity/index/BuildActivityIndexes.java
@@ -19,6 +19,10 @@ public class BuildActivityIndexes {
 	@Autowired
 	private StepBuilderFactory stepBuilderFactory;
 
+	@Autowired
+	@Qualifier("buildActivityActivityIndex")
+	private Tasklet buildActivityActivityIndex;
+
 //WQP-1400
 //	@Autowired
 //	@Qualifier("buildActivityCountryIndex")
@@ -76,6 +80,13 @@ public class BuildActivityIndexes {
 //	@Qualifier("buildActivityStationIndex")
 //	private Tasklet buildActivityStationIndex;
 //
+	@Bean
+	public Step buildActivityActivityIndexStep() {
+		return stepBuilderFactory.get("buildActivityActivityIndexStep")
+				.tasklet(buildActivityActivityIndex)
+				.build();
+	}
+
 //
 //	@Bean
 //	public Step buildActivityCountryIndexStep() {
@@ -178,7 +189,7 @@ public class BuildActivityIndexes {
 	@Bean
 	public Flow buildActivityIndexesFlow() {
 		return new FlowBuilder<SimpleFlow>(EtlConstantUtils.BUILD_ACTIVITY_INDEXES_FLOW)
-				.start(buildActivityOrganizationIndexStep())
+				.start(buildActivityActivityIndexStep())
 //				.start(buildActivityCountryIndexStep())
 //				.next(buildActivityCountyIndexStep())
 //				.next(buildActivityGeomIndexStep())
@@ -188,7 +199,7 @@ public class BuildActivityIndexes {
 //				.next(buildActivityHuc4IndexStep())
 //				.next(buildActivityHuc6IndexStep())
 //				.next(buildActivityHuc8IndexStep())
-//				.next(buildActivityOrganizationIndexStep())
+				.next(buildActivityOrganizationIndexStep())
 //				.next(buildActivitySiteIndexStep())
 //				.next(buildActivitySiteTypeIndexStep())
 //				.next(buildActivityStateIndexStep())

--- a/src/main/java/gov/acwi/wqp/etl/index/BuildActivityIndex.java
+++ b/src/main/java/gov/acwi/wqp/etl/index/BuildActivityIndex.java
@@ -1,0 +1,21 @@
+package gov.acwi.wqp.etl.index;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import gov.acwi.wqp.etl.FunctionCallTasklet;
+
+public abstract class BuildActivityIndex extends FunctionCallTasklet {
+
+	public static final String FUNCTION_NAME = "build_activity_index";
+
+	public BuildActivityIndex(JdbcTemplate jdbcTemplate,
+			String wqpDataSource,
+			String wqpSchemaName) {
+		super(jdbcTemplate, wqpDataSource, wqpSchemaName);
+	}
+
+	protected String getFunctionName() {
+		return FUNCTION_NAME;
+	}
+
+}

--- a/src/main/resources/db/changelog/functions/index/activity/activity.sql
+++ b/src/main/resources/db/changelog/functions/index/activity/activity.sql
@@ -1,0 +1,11 @@
+create or replace function build_activity_index(wqp_data_source character varying, wqp_schema_name character varying, base_table_name character varying)
+returns void
+language plpgsql
+as $$
+declare
+    swap_table_name varchar := base_table_name || '_swap_' || wqp_data_source;
+    index_name varchar := swap_table_name || '_activity';
+begin
+    execute format('create index if not exists %I on %I.%I(activity) with (fillfactor = 100)', index_name, wqp_schema_name, swap_table_name);
+end
+$$

--- a/src/main/resources/db/changelog/functions/index/activity/changeLog.yml
+++ b/src/main/resources/db/changelog/functions/index/activity/changeLog.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - preConditions:
+    - dbms:
+        type: postgresql
+
+  - changeSet:
+      author: drsteini
+      id: "create.function.build_activity_index"
+      changes:
+        - sqlFile:
+            path: activity.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+        - rollback: drop function if exists build_activity_index(character varying,character varying,character varying);

--- a/src/main/resources/db/changelog/functions/index/changeLog.yml
+++ b/src/main/resources/db/changelog/functions/index/changeLog.yml
@@ -4,6 +4,10 @@ databaseChangeLog:
         type: postgresql
 
   - include:
+      file: "activity/changeLog.yml"
+      relativeToChangelogFile: true
+
+  - include:
       file: "codeValue/changeLog.yml"
       relativeToChangelogFile: true
 

--- a/src/test/java/gov/acwi/wqp/etl/activity/index/BuildActivityIndexesFlowIT.java
+++ b/src/test/java/gov/acwi/wqp/etl/activity/index/BuildActivityIndexesFlowIT.java
@@ -35,6 +35,22 @@ public class BuildActivityIndexesFlowIT extends BaseFlowIT {
 	}
 
 	@Test
+	@ExpectedDatabase(value="classpath:/testResult/wqp/activity/indexes/activity.xml",
+			assertionMode=DatabaseAssertionMode.NON_STRICT_UNORDERED,
+			table=EXPECTED_DATABASE_TABLE_CHECK_INDEX,
+			query=EXPECTED_DATABASE_QUERY + " and indexname='activity_swap_testsrc_activity'")
+	public void buildActivityActivityIndexStepTest() {
+		try {
+			JobExecution jobExecution = jobLauncherTestUtils
+					.launchStep("buildActivityActivityIndexStep", testJobParameters);
+			assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getLocalizedMessage());
+		}
+	}
+
+	@Test
 	@ExpectedDatabase(value="classpath:/testResult/wqp/activity/indexes/organization.xml",
 			assertionMode=DatabaseAssertionMode.NON_STRICT_UNORDERED,
 			table=EXPECTED_DATABASE_TABLE_CHECK_INDEX,

--- a/src/test/resources/testResult/wqp/activity/indexes/activity.xml
+++ b/src/test/resources/testResult/wqp/activity/indexes/activity.xml
@@ -5,9 +5,4 @@
         indexname="activity_swap_testsrc_activity"
         indexdef="CREATE INDEX activity_swap_testsrc_activity ON wqp.activity_swap_testsrc USING btree (activity) WITH (fillfactor='100')"
      />
-    <pg_indexes
-        tablename="activity_swap_testsrc"
-        indexname="activity_swap_testsrc_organization"
-        indexdef="CREATE INDEX activity_swap_testsrc_organization ON wqp.activity_swap_testsrc USING btree (organization) WITH (fillfactor='100')"
-     />
 </dataset>


### PR DESCRIPTION
The index was added in a failed attempt to get the stewards etl working faster. While the current (EROS-like) code does not require this, it seemed to valuable to throw away, only to re-add for WQP-1400