### PR TITLE
removed /* comments */ from sql templates during processing

### DIFF
--- a/src/main/java/gov/acwi/wqp/etl/SqlTemplateTasklet.java
+++ b/src/main/java/gov/acwi/wqp/etl/SqlTemplateTasklet.java
@@ -10,7 +10,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.FileCopyUtils;
 
 import java.io.*;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -56,7 +55,9 @@ public abstract class SqlTemplateTasklet implements Tasklet  {
 
 	public String getSqlString(Map<String, String> params) {
 
-		var wrap = new Object() { public String text = getSqlTemplate(); };
+		final String noComment = getSqlTemplate().replaceAll("(?s)\\/\\*.*?\\*\\/", ""); //remove all /* ... */ comments
+
+		var wrap = new Object() { public String text = noComment; };
 
 		params.entrySet().stream().forEach(e -> {
 			wrap.text = wrap.text.replace("${" + e.getKey() + "}", e.getValue());

--- a/src/main/java/gov/acwi/wqp/etl/SqlTemplateTasklet.java
+++ b/src/main/java/gov/acwi/wqp/etl/SqlTemplateTasklet.java
@@ -55,7 +55,7 @@ public abstract class SqlTemplateTasklet implements Tasklet  {
 
 	public String getSqlString(Map<String, String> params) {
 
-		final String noComment = getSqlTemplate().replaceAll("(?s)\\/\\*.*?\\*\\/", ""); //remove all /* ... */ comments
+		final String noComment = getSqlTemplate().replaceAll("(?s)/\\*.*?\\*/", ""); //remove all /* ... */ comments
 
 		var wrap = new Object() { public String text = noComment; };
 

--- a/src/test/java/gov/acwi/wqp/etl/AttachRangePartitionTableTest.java
+++ b/src/test/java/gov/acwi/wqp/etl/AttachRangePartitionTableTest.java
@@ -14,9 +14,6 @@ class AttachRangePartitionTableTest {
 
 		String str = task.getSqlString();
 
-		//Strip out the comments at the top of the file, since they will look the 'correct answer'.  Comments end with "*/".
-		str = str.substring(str.indexOf("*/") + 2);
-
 		assertTrue(str.matches("(?si).*alter table\\s+xyz\\.parenttable.*"));
 		assertTrue(str.matches("(?si).*for values from\\s+\\('1999-01-01'\\)\\s+to\\s+\\('2000-7-01'\\)\\s*"));
 

--- a/src/test/java/gov/acwi/wqp/etl/CreateTableLikeTest.java
+++ b/src/test/java/gov/acwi/wqp/etl/CreateTableLikeTest.java
@@ -1,15 +1,8 @@
 package gov.acwi.wqp.etl;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.util.FileCopyUtils;
 
-import java.io.*;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CreateTableLikeTest {
 
@@ -19,9 +12,6 @@ class CreateTableLikeTest {
 		CreateTableLike task = new CreateTableLike(null, "xyz", "mytable", "othertable");
 
 		String str = task.getSqlString();
-
-		//Strip out the comments at the top of the file, since they will look the 'correct answer'.  Comments end with "*/".
-		str = str.substring(str.indexOf("*/") + 2);
 
 		//create table ${wqp_schema_name}.${table_name}
 		//    (like ${wqp_schema_name}.${like_table_name} including comments including defaults including identity) with (fillfactor = 100)

--- a/src/test/java/gov/acwi/wqp/etl/SqlTemplateTaskletTest.java
+++ b/src/test/java/gov/acwi/wqp/etl/SqlTemplateTaskletTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SqlTemplateTaskletTest {
@@ -25,8 +26,7 @@ class SqlTemplateTaskletTest {
 
 		String str = test.getSqlString();
 
-		//Strip out the comments at the top of the file, since they will look the 'correct answer'.  Comments end with "*/".
-		str = str.substring(str.indexOf("*/") + 2);
+		assertFalse(str.matches("(?s).*\\/\\*.*\\*\\/.*")); //There should be no comments in the text
 
 		//create table ${wqp_schema_name}.${table_name}
 		//    (like ${wqp_schema_name}.${like_table_name} including comments) with (fillfactor = 100)

--- a/src/test/resources/gov/acwi/wqp/etl/SqlTemplateTest.sql
+++ b/src/test/resources/gov/acwi/wqp/etl/SqlTemplateTest.sql
@@ -1,5 +1,7 @@
 /*
     Sample chunk of SQL to use as a template for a test
  */
-create table ${wqp_schema_name}.${table_name}
+create table ${wqp_schema_name}.${table_name} /* Could be line comments */
     (like ${wqp_schema_name}.${like_table_name} including comments) with (fillfactor = 100)
+/* And there could be
+   comments at the end */


### PR DESCRIPTION
Someday we may have optimizer hints in comments, but for now it seems like they just make the debug way harder to read.